### PR TITLE
Feat/#11 경기 관련 기능 구현

### DIFF
--- a/src/main/java/com/tickeTeam/common/exception/ErrorCode.java
+++ b/src/main/java/com/tickeTeam/common/exception/ErrorCode.java
@@ -17,8 +17,8 @@ public enum ErrorCode {
 
     // Game
     GAME_DATA_INSERT_ERROR(500,"GA001", "game 데이터 삽입 중 오류 발생"),
-    MATCHES_NOT_FOUND(404, "GA002", "일주일 내 경기들을 찾을 수 없음"),
-    MATCH_NOT_FOUND(404, "GA003", "해당 경기를 찾을 수 없음"),
+    MATCH_NOT_FOUND(404, "GA002", "해당 경기를 찾을 수 없음"),
+
     // Team
     TEAM_NOT_FOUND(404,"T001","팀 찾을 수 없음"),
 

--- a/src/main/java/com/tickeTeam/common/exception/ErrorCode.java
+++ b/src/main/java/com/tickeTeam/common/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
 
     // Game
     GAME_DATA_INSERT_ERROR(500,"GA001", "game 데이터 삽입 중 오류 발생"),
-
+    MATCHES_NOT_FOUND(404, "GA002", "일주일 내 경기들을 찾을 수 없음"),
+    MATCH_NOT_FOUND(404, "GA003", "해당 경기를 찾을 수 없음"),
     // Team
     TEAM_NOT_FOUND(404,"T001","팀 찾을 수 없음"),
 

--- a/src/main/java/com/tickeTeam/common/result/ResultCode.java
+++ b/src/main/java/com/tickeTeam/common/result/ResultCode.java
@@ -15,9 +15,10 @@ public enum ResultCode {
     LOGIN_FAIL("M003", "로그인에 실패했습니다. 비밀번호를 확인해주세요."),
     LOGIN_SUCCESS("M004", "로그인 성공하였습니다."),
     MY_PAGE("M005", "마이페이지 조회에 성공했습니다."),
-    MEMBER_UPDATE_SUCCESS("M006", "회원 정보 수정에 성공했습니다.")
-    // Game
+    MEMBER_UPDATE_SUCCESS("M006", "회원 정보 수정에 성공했습니다."),
 
+    // Game
+    GET_WEEKLY_GAME_SUCCESS("G001", "일주일 이내 경기 목록 조회에 성공했습니다."),
     // Seat
     ;
 

--- a/src/main/java/com/tickeTeam/common/result/ResultCode.java
+++ b/src/main/java/com/tickeTeam/common/result/ResultCode.java
@@ -19,7 +19,9 @@ public enum ResultCode {
 
     // Game
     GET_WEEKLY_GAME_SUCCESS("G001", "일주일 이내 경기 목록 조회에 성공했습니다."),
+
     // Seat
+    GET_GAME_SEAT_SUCCESS("S001", "경기 좌석 조회에 성공했습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/tickeTeam/domain/game/controller/GameController.java
+++ b/src/main/java/com/tickeTeam/domain/game/controller/GameController.java
@@ -1,0 +1,23 @@
+package com.tickeTeam.domain.game.controller;
+
+import com.tickeTeam.common.result.ResultResponse;
+import com.tickeTeam.domain.game.service.GameService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/game")
+@RequiredArgsConstructor
+public class GameController {
+
+    private final GameService gameService;
+
+    @GetMapping("/upcoming")
+    public ResponseEntity<ResultResponse> getGamesInNextSevenDays(HttpServletRequest request){
+        return ResponseEntity.ok(gameService.findGamesInNextSevenDays(request));
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/game/controller/GameController.java
+++ b/src/main/java/com/tickeTeam/domain/game/controller/GameController.java
@@ -18,6 +18,6 @@ public class GameController {
 
     @GetMapping("/upcoming")
     public ResponseEntity<ResultResponse> getGamesInNextSevenDays(HttpServletRequest request){
-        return ResponseEntity.ok(gameService.findGamesInNextSevenDays(request));
+        return ResponseEntity.ok(gameService.getGamesInNextSevenDays(request));
     }
 }

--- a/src/main/java/com/tickeTeam/domain/game/dto/response/GameInfoResponse.java
+++ b/src/main/java/com/tickeTeam/domain/game/dto/response/GameInfoResponse.java
@@ -1,0 +1,36 @@
+package com.tickeTeam.domain.game.dto.response;
+
+import com.tickeTeam.domain.game.entity.Game;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GameInfoResponse {
+
+    private Long gameId;
+
+    private String homeTeamName;
+
+    private String awayTeamName;
+
+    private String stadiumName;
+
+    private LocalDate matchDay;
+
+    private LocalTime matchTime;
+
+    public static GameInfoResponse from(Game game) {
+        return new GameInfoResponse(
+                game.getId(),
+                game.getHomeTeam().getTeamName(),
+                game.getAwayTeam().getTeamName(),
+                game.getStadium().getStadiumName(),
+                game.getMatchDay(),
+                game.getMatchTime()
+        );
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/game/dto/response/WeeklyGamesResponse.java
+++ b/src/main/java/com/tickeTeam/domain/game/dto/response/WeeklyGamesResponse.java
@@ -13,9 +13,13 @@ import lombok.Getter;
 public class WeeklyGamesResponse {
 
     private List<GameInfoResponse> games; // 실제 경기 정보 리스트
+
     private LocalDate startDate;          // 주간 조회 시작일
+
     private LocalDate endDate;            // 주간 조회 종료일
+
     private String team;                  // 조회 대상 응원팀
+
     private int totalGames;               // 조회된 총 경기 수
 
 

--- a/src/main/java/com/tickeTeam/domain/game/dto/response/WeeklyGamesResponse.java
+++ b/src/main/java/com/tickeTeam/domain/game/dto/response/WeeklyGamesResponse.java
@@ -1,0 +1,29 @@
+package com.tickeTeam.domain.game.dto.response;
+
+import com.tickeTeam.domain.game.entity.Game;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class WeeklyGamesResponse {
+
+    private List<GameInfoResponse> games; // 실제 경기 정보 리스트
+    private LocalDate startDate;          // 주간 조회 시작일
+    private LocalDate endDate;            // 주간 조회 종료일
+    private String team;                  // 조회 대상 응원팀
+    private int totalGames;               // 조회된 총 경기 수
+
+
+    public static WeeklyGamesResponse of(List<Game> matches, LocalDate weekStartDate, LocalDate weekEndDate, String teamName ){
+        List<GameInfoResponse> gameInfoResponses = matches.stream()
+                .map(GameInfoResponse::from)
+                .toList();
+
+        return new WeeklyGamesResponse(gameInfoResponses, weekStartDate, weekEndDate, teamName, gameInfoResponses.size());
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/game/entity/Game.java
+++ b/src/main/java/com/tickeTeam/domain/game/entity/Game.java
@@ -15,9 +15,11 @@ import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/tickeTeam/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/tickeTeam/domain/game/repository/GameRepository.java
@@ -1,11 +1,29 @@
 package com.tickeTeam.domain.game.repository;
 
 import com.tickeTeam.domain.game.entity.Game;
+import com.tickeTeam.domain.member.entity.Team;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
     List<Game> findByMatchDayBetweenAndStadium_Id(LocalDate startDate, LocalDate endDate, Long stadium_id);
+
+    /**
+     * 특정 기간 내에 주어진 팀이 홈팀이거나 어웨이팀으로 참여하는 모든 경기를 조회(朝會)
+     * @param startDate 조회 시작일
+     * @param endDate 조회 종료일
+     * @param team 조회할 팀
+     * @return 조건에 맞는 경기 목록 (없으면 빈 리스트)
+     */
+    @Query("SELECT g FROM Game g WHERE g.matchDay BETWEEN :startDate AND :endDate AND (g.homeTeam = :team OR g.awayTeam = :team) ORDER BY g.matchDay, g.matchTime")
+    List<Game> findGamesByTeamAndDateRange(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("team") Team team
+    );
 }

--- a/src/main/java/com/tickeTeam/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/tickeTeam/domain/game/repository/GameRepository.java
@@ -14,7 +14,7 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     List<Game> findByMatchDayBetweenAndStadium_Id(LocalDate startDate, LocalDate endDate, Long stadium_id);
 
     /**
-     * 특정 기간 내에 주어진 팀이 홈팀이거나 어웨이팀으로 참여하는 모든 경기를 조회(朝會)
+     * 특정 기간 내에 주어진 팀이 홈팀이거나 어웨이팀으로 참여하는 모든 경기를 조회
      * @param startDate 조회 시작일
      * @param endDate 조회 종료일
      * @param team 조회할 팀

--- a/src/main/java/com/tickeTeam/domain/game/service/GameService.java
+++ b/src/main/java/com/tickeTeam/domain/game/service/GameService.java
@@ -11,7 +11,6 @@ import com.tickeTeam.domain.game.repository.GameRepository;
 import com.tickeTeam.domain.member.entity.Member;
 import com.tickeTeam.domain.member.entity.Team;
 import com.tickeTeam.domain.member.repository.MemberRepository;
-import com.tickeTeam.domain.seat.repository.SeatRepository;
 import com.tickeTeam.infrastructure.security.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
@@ -29,11 +28,10 @@ public class GameService {
 
     private final GameRepository gameRepository;
     private final MemberRepository memberRepository;
-    private final SeatRepository seatRepository;
     private final JwtUtil jwtUtil;
 
     // 7일 이내 경기 조회(조회 당일 기준)
-    public ResultResponse findGamesInNextSevenDays(HttpServletRequest request) {
+    public ResultResponse getGamesInNextSevenDays(HttpServletRequest request) {
         Member findMember = getMemberByRequest(request);
         Team findTeam = findMember.getFavoriteTeam();
 
@@ -46,10 +44,6 @@ public class GameService {
 
         return ResultResponse.of(ResultCode.GET_WEEKLY_GAME_SUCCESS, weeklyGamesResponse);
     }
-
-    // 경기 선택(좌석 정보 조회)
-
-
 
     private Member getMemberByRequest(HttpServletRequest request) {
         // jwt 토큰으로부터 추출한 이메일로 사용자 조회

--- a/src/main/java/com/tickeTeam/domain/game/service/GameService.java
+++ b/src/main/java/com/tickeTeam/domain/game/service/GameService.java
@@ -1,0 +1,70 @@
+package com.tickeTeam.domain.game.service;
+
+import com.tickeTeam.common.exception.ErrorCode;
+import com.tickeTeam.common.exception.customException.BusinessException;
+import com.tickeTeam.common.exception.customException.NotFoundException;
+import com.tickeTeam.common.result.ResultCode;
+import com.tickeTeam.common.result.ResultResponse;
+import com.tickeTeam.domain.game.dto.response.WeeklyGamesResponse;
+import com.tickeTeam.domain.game.entity.Game;
+import com.tickeTeam.domain.game.repository.GameRepository;
+import com.tickeTeam.domain.member.entity.Member;
+import com.tickeTeam.domain.member.entity.Team;
+import com.tickeTeam.domain.member.repository.MemberRepository;
+import com.tickeTeam.domain.seat.repository.SeatRepository;
+import com.tickeTeam.infrastructure.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GameService {
+
+    private static final String ACCESS_HEADER = "Authorization";
+    private static final String BEARER = "Bearer ";
+
+    private final GameRepository gameRepository;
+    private final MemberRepository memberRepository;
+    private final SeatRepository seatRepository;
+    private final JwtUtil jwtUtil;
+
+    // 7일 이내 경기 조회(조회 당일 기준)
+    public ResultResponse findGamesInNextSevenDays(HttpServletRequest request) {
+        Member findMember = getMemberByRequest(request);
+        Team findTeam = findMember.getFavoriteTeam();
+
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.plusDays(7);
+
+        List<Game> upcomingMatches = gameRepository.findGamesByTeamAndDateRange(today, endDate, findTeam);
+
+        WeeklyGamesResponse weeklyGamesResponse = WeeklyGamesResponse.of(upcomingMatches, today, endDate, findTeam.getTeamName());
+
+        return ResultResponse.of(ResultCode.GET_WEEKLY_GAME_SUCCESS, weeklyGamesResponse);
+    }
+
+    // 경기 선택(좌석 정보 조회)
+
+
+
+    private Member getMemberByRequest(HttpServletRequest request) {
+        // jwt 토큰으로부터 추출한 이메일로 사용자 조회
+        String memberEmail = jwtUtil.getEmail(extractAccessToken(request));
+        Member findMember = memberRepository.findByEmail(memberEmail).orElseThrow(
+                () -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND)
+        );
+        return findMember;
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(ACCESS_HEADER))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""))
+                .orElseThrow(() -> new BusinessException(ErrorCode.TOKEN_ACCESS_NOT_EXIST));
+    }
+
+}

--- a/src/main/java/com/tickeTeam/domain/game/service/GameService.java
+++ b/src/main/java/com/tickeTeam/domain/game/service/GameService.java
@@ -48,10 +48,9 @@ public class GameService {
     private Member getMemberByRequest(HttpServletRequest request) {
         // jwt 토큰으로부터 추출한 이메일로 사용자 조회
         String memberEmail = jwtUtil.getEmail(extractAccessToken(request));
-        Member findMember = memberRepository.findByEmail(memberEmail).orElseThrow(
+        return memberRepository.findByEmail(memberEmail).orElseThrow(
                 () -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND)
         );
-        return findMember;
     }
 
     private String extractAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/tickeTeam/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/tickeTeam/domain/member/service/MemberServiceImpl.java
@@ -82,10 +82,9 @@ public class MemberServiceImpl implements MemberService {
     private Member getMemberByRequest(HttpServletRequest request) {
         // jwt 토큰으로부터 추출한 이메일로 사용자 조회
         String memberEmail = jwtUtil.getEmail(extractAccessToken(request));
-        Member findMember = memberRepository.findByEmail(memberEmail).orElseThrow(
+        return memberRepository.findByEmail(memberEmail).orElseThrow(
                 () -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND)
         );
-        return findMember;
     }
 
     private String extractAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/tickeTeam/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/tickeTeam/domain/seat/controller/SeatController.java
@@ -1,0 +1,23 @@
+package com.tickeTeam.domain.seat.controller;
+
+import com.tickeTeam.common.result.ResultResponse;
+import com.tickeTeam.domain.seat.service.SeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/seat")
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @GetMapping("/{gameId}")
+    public ResponseEntity<ResultResponse> gameSeats(@PathVariable("gameId") Long gameId){
+        return ResponseEntity.ok(seatService.getGameSeats(gameId));
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/seat/dto/response/GameSeatsResponse.java
+++ b/src/main/java/com/tickeTeam/domain/seat/dto/response/GameSeatsResponse.java
@@ -1,0 +1,26 @@
+package com.tickeTeam.domain.seat.dto.response;
+
+import com.tickeTeam.domain.seat.entity.Seat;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GameSeatsResponse {
+
+    private Long gameId;
+
+    private String stadium;
+
+    private List<SeatInfoResponse> seats;
+
+    public static GameSeatsResponse of(List<Seat> seats, Long gameId, String stadium){
+        List<SeatInfoResponse> seatInfoList = seats.stream()
+                .map(SeatInfoResponse::from)
+                .toList();
+        return new GameSeatsResponse(gameId, stadium, seatInfoList);
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/seat/dto/response/SeatInfoResponse.java
+++ b/src/main/java/com/tickeTeam/domain/seat/dto/response/SeatInfoResponse.java
@@ -1,0 +1,42 @@
+package com.tickeTeam.domain.seat.dto.response;
+
+import com.tickeTeam.domain.seat.entity.Seat;
+import com.tickeTeam.domain.seat.entity.SeatInfo;
+import com.tickeTeam.domain.seat.entity.SeatStatus;
+import com.tickeTeam.domain.seat.entity.SeatType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SeatInfoResponse {
+
+    private Long id;
+
+    private SeatType seatType;
+
+    private String seatSection;
+
+    private String seatBlock;
+
+    private String seatRow;
+
+    private Integer seatNum;
+
+    private SeatStatus seatStatus;
+
+    public static SeatInfoResponse from(Seat seat) {
+        SeatInfo seatInfo = seat.getSeatTemplate().getSeatInfo();
+
+        return new SeatInfoResponse(
+                seat.getId(),
+                seatInfo.getSeatType(),
+                seatInfo.getSeatSection(),
+                seatInfo.getSeatBlock(),
+                seatInfo.getSeatRow(),
+                seatInfo.getSeatNum(),
+                seat.getSeatStatus()
+        );
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/tickeTeam/domain/seat/repository/SeatRepository.java
@@ -1,7 +1,11 @@
 package com.tickeTeam.domain.seat.repository;
 
+import com.tickeTeam.domain.game.entity.Game;
 import com.tickeTeam.domain.seat.entity.Seat;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    public List<Seat> findAllByGame(Game game);
 }

--- a/src/main/java/com/tickeTeam/domain/seat/service/SeatService.java
+++ b/src/main/java/com/tickeTeam/domain/seat/service/SeatService.java
@@ -1,0 +1,32 @@
+package com.tickeTeam.domain.seat.service;
+
+import com.tickeTeam.common.exception.ErrorCode;
+import com.tickeTeam.common.exception.customException.NotFoundException;
+import com.tickeTeam.common.result.ResultCode;
+import com.tickeTeam.common.result.ResultResponse;
+import com.tickeTeam.domain.game.entity.Game;
+import com.tickeTeam.domain.game.repository.GameRepository;
+import com.tickeTeam.domain.seat.dto.response.GameSeatsResponse;
+import com.tickeTeam.domain.seat.entity.Seat;
+import com.tickeTeam.domain.seat.repository.SeatRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+    private final GameRepository gameRepository;
+
+    // 좌석 정보 조회
+    public ResultResponse getGameSeats(Long gameId) {
+        Game findGame = gameRepository.findById(gameId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MATCH_NOT_FOUND));
+        List<Seat> seats = seatRepository.findAllByGame(findGame);
+        return ResultResponse.of(ResultCode.GET_GAME_SEAT_SUCCESS,
+                GameSeatsResponse.of(seats, gameId, findGame.getStadium().getStadiumName()));
+    }
+}

--- a/src/main/java/com/tickeTeam/domain/seat/service/SeatService.java
+++ b/src/main/java/com/tickeTeam/domain/seat/service/SeatService.java
@@ -10,7 +10,6 @@ import com.tickeTeam.domain.seat.dto.response.GameSeatsResponse;
 import com.tickeTeam.domain.seat.entity.Seat;
 import com.tickeTeam.domain.seat.repository.SeatRepository;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/tickeTeam/initializer/SeatInitializer.java
+++ b/src/main/java/com/tickeTeam/initializer/SeatInitializer.java
@@ -48,10 +48,9 @@ public class SeatInitializer implements ApplicationRunner {
         );
 
         LocalDate today = LocalDate.now();
-        LocalDate start = today.plusDays(DAYS_FROM_TODAY); // 내일
         LocalDate end = today.plusDays(DAYS_TO_END);   // 7일 뒤
 
-        List<Game> games = gameRepository.findByMatchDayBetweenAndStadium_Id(start, end, jamsil.getId());
+        List<Game> games = gameRepository.findByMatchDayBetweenAndStadium_Id(today, end, jamsil.getId());
         List<SeatTemplate> seatTemplates = seatTemplateRepository.findAll();
 
         List<Seat> seats = generateSeatsForGames(games, seatTemplates, jamsil);

--- a/src/test/java/com/tickeTeam/domain/game/service/GameServiceTest.java
+++ b/src/test/java/com/tickeTeam/domain/game/service/GameServiceTest.java
@@ -194,10 +194,4 @@ class GameServiceTest {
             verifyNoInteractions(gameRepository); // 사용자 조회 실패 시 게임 조회 로직은 실행 안됨
         }
     }
-
-    @Test
-    @DisplayName("선택한 경기 세부 정보 조회 성공 - 해당 경기의 좌석 정보를 반환합니다.")
-    void 경기_선택_성공() {
-
-    }
 }

--- a/src/test/java/com/tickeTeam/domain/game/service/GameServiceTest.java
+++ b/src/test/java/com/tickeTeam/domain/game/service/GameServiceTest.java
@@ -1,0 +1,203 @@
+package com.tickeTeam.domain.game.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.tickeTeam.common.exception.ErrorCode;
+import com.tickeTeam.common.exception.customException.NotFoundException;
+import com.tickeTeam.common.result.ResultCode;
+import com.tickeTeam.common.result.ResultResponse;
+import com.tickeTeam.domain.game.dto.response.WeeklyGamesResponse;
+import com.tickeTeam.domain.game.entity.Game;
+import com.tickeTeam.domain.game.repository.GameRepository;
+import com.tickeTeam.domain.member.entity.Member;
+import com.tickeTeam.domain.member.entity.Team;
+import com.tickeTeam.domain.member.repository.MemberRepository;
+import com.tickeTeam.domain.member.repository.TeamRepository;
+import com.tickeTeam.infrastructure.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GameServiceTest {
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private Team mockTeam;
+
+    @Mock
+    private Member mockMember;
+
+    @Mock
+    private WeeklyGamesResponse mockWeeklyGamesResponse;
+
+    @InjectMocks
+    GameService gameService;
+
+    private static final String ACCESS_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private String testEmail;
+    private String testToken;
+    private LocalDate fixedCurrentDate;
+    private LocalDate endDate;
+    private List<Game> mockGameList;
+
+    @BeforeEach
+    void setUp() {
+        testEmail = "test@example.com";
+        testToken = "testToken";
+        fixedCurrentDate = LocalDate.of(2025, 5, 16);
+        endDate = fixedCurrentDate.plusDays(7);
+    }
+
+    @Test
+    @DisplayName("현재 날짜 기준 7일 이내의 응원팀 경기 조회 성공")
+    void 응원팀_경기_조회_성공() {
+        try (MockedStatic<LocalDate> mockedDate = mockStatic(LocalDate.class);
+             MockedStatic<WeeklyGamesResponse> mockedResponse = mockStatic(WeeklyGamesResponse.class)) {
+
+            // 준비
+            mockedDate.when(LocalDate::now).thenReturn(fixedCurrentDate);
+
+            when(request.getHeader(ACCESS_HEADER)).thenReturn(BEARER_PREFIX + testToken);
+            when(jwtUtil.getEmail(testToken)).thenReturn(testEmail);
+            when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.of(mockMember));
+            when(mockMember.getFavoriteTeam()).thenReturn(mockTeam);
+            mockGameList = List.of(mock(Game.class), mock(Game.class));
+            when(gameRepository.findGamesByTeamAndDateRange(fixedCurrentDate, endDate, mockTeam))
+                    .thenReturn(mockGameList);
+            when(mockTeam.getTeamName()).thenReturn("기아 타이거즈");
+            mockedResponse.when(() -> WeeklyGamesResponse.of(
+                    eq(mockGameList), eq(fixedCurrentDate), eq(endDate), eq("기아 타이거즈")
+            )).thenReturn(mockWeeklyGamesResponse);
+
+            // 실행
+            ResultResponse resultResponse = gameService.findGamesInNextSevenDays(request);
+
+            // 검증
+            assertThat(resultResponse).isNotNull();
+            assertThat(resultResponse.getCode()).isEqualTo(ResultCode.GET_WEEKLY_GAME_SUCCESS.getCode());
+            assertThat(resultResponse.getMessage()).isEqualTo(ResultCode.GET_WEEKLY_GAME_SUCCESS.getMessage());
+            assertThat(resultResponse.getData()).isEqualTo(mockWeeklyGamesResponse);
+
+            verify(request).getHeader(ACCESS_HEADER);
+            verify(jwtUtil).getEmail(testToken);
+            verify(memberRepository).findByEmail(testEmail);
+            verify(mockMember).getFavoriteTeam();
+            verify(gameRepository).findGamesByTeamAndDateRange(fixedCurrentDate, endDate, mockTeam);
+            mockedResponse.verify(() -> WeeklyGamesResponse.of(
+                    mockGameList, fixedCurrentDate, endDate, "기아 타이거즈"
+            ));
+        }
+    }
+
+    @Test
+    @DisplayName("경기 목록 조회 - 7일 이내 경기가 존재하지 않으면 빈 리스트를 반환합니다")
+    void 경기_조회_성공_경기_없음() {
+        try (MockedStatic<LocalDate> mockedDate = mockStatic(LocalDate.class);
+             MockedStatic<WeeklyGamesResponse> mockedResponse = mockStatic(WeeklyGamesResponse.class)) {
+
+            // 준비
+            mockedDate.when(LocalDate::now).thenReturn(fixedCurrentDate);
+
+            when(request.getHeader(ACCESS_HEADER)).thenReturn(BEARER_PREFIX + testToken);
+            when(jwtUtil.getEmail(testToken)).thenReturn(testEmail);
+            when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.of(mockMember));
+            when(mockMember.getFavoriteTeam()).thenReturn(mockTeam);
+
+            mockGameList = Collections.emptyList();
+            when(gameRepository.findGamesByTeamAndDateRange(fixedCurrentDate, endDate, mockTeam))
+                    .thenReturn(mockGameList);
+
+            when(mockTeam.getTeamName()).thenReturn("기아 타이거즈");
+            mockedResponse.when(() -> WeeklyGamesResponse.of(
+                    eq(mockGameList), eq(fixedCurrentDate), eq(endDate), eq("기아 타이거즈")
+            )).thenReturn(mockWeeklyGamesResponse);
+            when(mockWeeklyGamesResponse.getGames()).thenReturn(Collections.emptyList());
+
+            // 실행
+            ResultResponse resultResponse = gameService.findGamesInNextSevenDays(request);
+
+            // 검증
+            assertThat(resultResponse).isNotNull();
+            assertThat(resultResponse.getCode()).isEqualTo(ResultCode.GET_WEEKLY_GAME_SUCCESS.getCode());
+            assertThat(resultResponse.getMessage()).isEqualTo(ResultCode.GET_WEEKLY_GAME_SUCCESS.getMessage());
+            assertThat(resultResponse.getData()).isEqualTo(mockWeeklyGamesResponse);
+
+            WeeklyGamesResponse resultResponseData = (WeeklyGamesResponse) resultResponse.getData();
+            assertThat(resultResponseData.getGames()).isEqualTo(Collections.emptyList()); // 빈 리스트를 반환하는지 검증
+
+            verify(request).getHeader(ACCESS_HEADER);
+            verify(jwtUtil).getEmail(testToken);
+            verify(memberRepository).findByEmail(testEmail);
+            verify(mockMember).getFavoriteTeam();
+            verify(gameRepository).findGamesByTeamAndDateRange(fixedCurrentDate, endDate, mockTeam);
+            mockedResponse.verify(() -> WeeklyGamesResponse.of(
+                    mockGameList, fixedCurrentDate, endDate, "기아 타이거즈"
+            ));
+        }
+    }
+
+    @Test
+    @DisplayName("경기 조회 실패 - 사용자 정보 없음")
+    void 경기_조회_실패_사용자_못찾음(){
+        try (MockedStatic<LocalDate> mockedDate = mockStatic(LocalDate.class);
+             MockedStatic<WeeklyGamesResponse> mockedResponse = mockStatic(WeeklyGamesResponse.class)) {
+
+            // 준비
+            mockedDate.when(LocalDate::now).thenReturn(fixedCurrentDate);
+
+            when(request.getHeader(ACCESS_HEADER)).thenReturn(BEARER_PREFIX + testToken);
+            when(jwtUtil.getEmail(testToken)).thenReturn(testEmail);
+            when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
+
+            // 실행 & 검증
+            assertThatThrownBy(() -> gameService.findGamesInNextSevenDays(request))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+            verify(request).getHeader(ACCESS_HEADER);
+            verify(jwtUtil).getEmail(testToken);
+            verify(memberRepository).findByEmail(testEmail);
+            verifyNoInteractions(gameRepository); // 사용자 조회 실패 시 게임 조회 로직은 실행 안됨
+        }
+    }
+
+    @Test
+    @DisplayName("선택한 경기 세부 정보 조회 성공 - 해당 경기의 좌석 정보를 반환합니다.")
+    void 경기_선택_성공() {
+    
+    }
+}

--- a/src/test/java/com/tickeTeam/domain/game/service/GameServiceTest.java
+++ b/src/test/java/com/tickeTeam/domain/game/service/GameServiceTest.java
@@ -104,7 +104,7 @@ class GameServiceTest {
             )).thenReturn(mockWeeklyGamesResponse);
 
             // 실행
-            ResultResponse resultResponse = gameService.findGamesInNextSevenDays(request);
+            ResultResponse resultResponse = gameService.getGamesInNextSevenDays(request);
 
             // 검증
             assertThat(resultResponse).isNotNull();
@@ -148,7 +148,7 @@ class GameServiceTest {
             when(mockWeeklyGamesResponse.getGames()).thenReturn(Collections.emptyList());
 
             // 실행
-            ResultResponse resultResponse = gameService.findGamesInNextSevenDays(request);
+            ResultResponse resultResponse = gameService.getGamesInNextSevenDays(request);
 
             // 검증
             assertThat(resultResponse).isNotNull();
@@ -184,7 +184,7 @@ class GameServiceTest {
             when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
 
             // 실행 & 검증
-            assertThatThrownBy(() -> gameService.findGamesInNextSevenDays(request))
+            assertThatThrownBy(() -> gameService.getGamesInNextSevenDays(request))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
 
@@ -198,6 +198,6 @@ class GameServiceTest {
     @Test
     @DisplayName("선택한 경기 세부 정보 조회 성공 - 해당 경기의 좌석 정보를 반환합니다.")
     void 경기_선택_성공() {
-    
+
     }
 }

--- a/src/test/java/com/tickeTeam/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/tickeTeam/domain/member/service/MemberServiceImplTest.java
@@ -57,7 +57,6 @@ class MemberServiceImplTest {
     @InjectMocks
     private MemberServiceImpl memberService;
 
-    // 테스트에 사용될 상수 정의
     private static final String ACCESS_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
@@ -151,10 +150,9 @@ class MemberServiceImplTest {
         when(teamRepository.findByTeamName(testSignUpRequest.getFavoriteTeam())).thenReturn(Optional.empty());
 
         // 실행
-        NotFoundException exception = assertThrows(NotFoundException.class, () -> {
-            memberService.signUp(testSignUpRequest);
-        });
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.TEAM_NOT_FOUND);
+        assertThatThrownBy(() -> memberService.signUp(testSignUpRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.TEAM_NOT_FOUND.getMessage());
 
         // 검증
         verify(memberRepository).existsByEmail(testSignUpRequest.getEmail());
@@ -191,10 +189,9 @@ class MemberServiceImplTest {
         when(request.getHeader(ACCESS_HEADER)).thenReturn(null);
 
         // 실행 & 검증
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
-            memberService.myPage(request);
-        });
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.TOKEN_ACCESS_NOT_EXIST);
+        assertThatThrownBy(() -> memberService.myPage(request))
+                .isInstanceOf(BusinessException.class)
+                        .hasMessage(ErrorCode.TOKEN_ACCESS_NOT_EXIST.getMessage());
 
         verify(request).getHeader(ACCESS_HEADER);
         verifyNoInteractions(jwtUtil); // jwtUtil 호출 안되어야 함
@@ -210,10 +207,10 @@ class MemberServiceImplTest {
         when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
 
         // 실행 & 검증
-        NotFoundException exception = assertThrows(NotFoundException.class, () -> {
-            memberService.myPage(request);
-        });
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+        assertThatThrownBy(() -> memberService.myPage(request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+
 
         verify(request).getHeader(ACCESS_HEADER);
         verify(jwtUtil).getEmail(testToken);
@@ -251,10 +248,9 @@ class MemberServiceImplTest {
         when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.of(mockExistingMember));
         when(teamRepository.findByTeamName(testUpdateRequest.getFavoriteTeam())).thenReturn(Optional.empty());
 
-        NotFoundException exception = assertThrows(NotFoundException.class, () -> {
-            memberService.updateMember(testUpdateRequest, request);
-        });
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.TEAM_NOT_FOUND);
+        assertThatThrownBy(() -> memberService.updateMember(testUpdateRequest, request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.TEAM_NOT_FOUND.getMessage());
 
         verify(request).getHeader(ACCESS_HEADER);
         verify(jwtUtil).getEmail(testToken);
@@ -271,10 +267,9 @@ class MemberServiceImplTest {
         when(memberRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
 
         // 실행 & 검증
-        NotFoundException exception = assertThrows(NotFoundException.class, () -> {
-            memberService.updateMember(testUpdateRequest, request);
-        });
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+        assertThatThrownBy(() -> memberService.updateMember(testUpdateRequest, request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
 
         verify(request).getHeader(ACCESS_HEADER);
         verify(jwtUtil).getEmail(testToken);

--- a/src/test/java/com/tickeTeam/domain/seat/service/SeatServiceTest.java
+++ b/src/test/java/com/tickeTeam/domain/seat/service/SeatServiceTest.java
@@ -1,0 +1,146 @@
+package com.tickeTeam.domain.seat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.tickeTeam.common.exception.ErrorCode;
+import com.tickeTeam.common.exception.customException.NotFoundException;
+import com.tickeTeam.common.result.ResultCode;
+import com.tickeTeam.common.result.ResultResponse;
+import com.tickeTeam.domain.game.entity.Game;
+import com.tickeTeam.domain.game.repository.GameRepository;
+import com.tickeTeam.domain.seat.dto.response.GameSeatsResponse;
+import com.tickeTeam.domain.seat.entity.Seat;
+import com.tickeTeam.domain.seat.repository.SeatRepository;
+import com.tickeTeam.domain.stadium.entity.Stadium;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatServiceTest {
+
+    @Mock
+    private SeatRepository seatRepository;
+
+    @Mock
+    private GameRepository gameRepository;
+
+    @Mock
+    private Game mockGame;
+
+    @Mock
+    private GameSeatsResponse mockGameSeatsResponse;
+
+    @InjectMocks
+    private SeatService seatService;
+
+    private Long testGameId;
+    private List<Seat> mockSeats;
+
+    @BeforeEach
+    void setup(){
+        testGameId = 1L;
+        mockGame = Game.builder()
+                .id(1L)
+                .stadium(Stadium.of("잠실 야구장"))
+                .build();
+
+    }
+
+    @Test
+    @DisplayName("경기 좌석 조회 성공 - 해당 경기에 해당하는 좌석 목록을 반환합니다.")
+    void 경기_좌석_조회_성공(){
+        try(MockedStatic<GameSeatsResponse> mockedResponse = mockStatic(GameSeatsResponse.class)) {
+            // 준비
+            when(gameRepository.findById(testGameId)).thenReturn(Optional.of(mockGame));
+
+            mockSeats = List.of(mock(Seat.class), mock(Seat.class));
+            when(seatRepository.findAllByGame(mockGame)).thenReturn(mockSeats);
+
+            mockedResponse.when(() -> GameSeatsResponse.of(
+                    eq(mockSeats), eq(testGameId), eq("잠실 야구장")
+            )).thenReturn(mockGameSeatsResponse);
+
+            // 실행
+            ResultResponse resultResponse = seatService.getGameSeats(testGameId);
+
+            // 검증
+            assertThat(resultResponse).isNotNull();
+            assertThat(resultResponse.getMessage()).isEqualTo(ResultCode.GET_GAME_SEAT_SUCCESS.getMessage());
+            assertThat(resultResponse.getCode()).isEqualTo(ResultCode.GET_GAME_SEAT_SUCCESS.getCode());
+            assertThat(resultResponse.getData()).isEqualTo(mockGameSeatsResponse);
+
+            verify(gameRepository).findById(testGameId);
+            verify(seatRepository).findAllByGame(mockGame);
+            mockedResponse.verify(() -> GameSeatsResponse.of(
+                    mockSeats, testGameId, "잠실 야구장"
+            ));
+        }
+    }
+
+    @Test
+    @DisplayName("경기 좌석 조회 성공 - 해당 경기에 해당하는 좌석이 없으면 빈 리스트를 반환합니다.")
+    void 경기_좌석_조회_성공_좌석_없음(){
+        try(MockedStatic<GameSeatsResponse> mockedResponse = mockStatic(GameSeatsResponse.class)) {
+            // 준비
+            when(gameRepository.findById(testGameId)).thenReturn(Optional.of(mockGame));
+
+            mockSeats = Collections.emptyList();
+            when(seatRepository.findAllByGame(mockGame)).thenReturn(mockSeats);
+
+            mockedResponse.when(() -> GameSeatsResponse.of(
+                    eq(mockSeats), eq(testGameId), eq("잠실 야구장")
+            )).thenReturn(mockGameSeatsResponse);
+            when(mockGameSeatsResponse.getSeats()).thenReturn(Collections.emptyList());
+
+            // 실행
+            ResultResponse resultResponse = seatService.getGameSeats(testGameId);
+
+            // 검증
+            assertThat(resultResponse).isNotNull();
+            assertThat(resultResponse.getMessage()).isEqualTo(ResultCode.GET_GAME_SEAT_SUCCESS.getMessage());
+            assertThat(resultResponse.getCode()).isEqualTo(ResultCode.GET_GAME_SEAT_SUCCESS.getCode());
+            assertThat(resultResponse.getData()).isEqualTo(mockGameSeatsResponse);
+
+            GameSeatsResponse gameSeatsResponse = (GameSeatsResponse) resultResponse.getData();
+            assertThat(gameSeatsResponse.getSeats()).isEqualTo(Collections.emptyList());
+
+            verify(gameRepository).findById(testGameId);
+            verify(seatRepository).findAllByGame(mockGame);
+            mockedResponse.verify(() -> GameSeatsResponse.of(
+                    mockSeats, testGameId, "잠실 야구장"
+            ));
+        }
+    }
+
+    @Test
+    @DisplayName("경기 좌석 조회 실패 - ID에 해당하는 경기를 찾지 못함")
+    void 경기_좌석_조회_실패_경기_못찾음(){
+        // 준비
+        when(gameRepository.findById(testGameId)).thenReturn(Optional.empty());
+
+        // 실행 & 검증
+        assertThatThrownBy(() -> seatService.getGameSeats(testGameId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.MATCH_NOT_FOUND.getMessage());
+
+        verify(gameRepository).findById(testGameId);
+        verifyNoInteractions(seatRepository);
+    }
+
+}


### PR DESCRIPTION
- 경기 조회
  - 응원팀으로 설정한 팀의 경기만을 조회
  - 조회되는 경기는 조회일자 기준 7일 이내의 경기

- 특정 경기 좌석 조회
  - 경기를 선택하면 해당 경기의 좌석 정보를 제공